### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/shapelet/GaussHermiteConvolution.h
+++ b/include/lsst/shapelet/GaussHermiteConvolution.h
@@ -73,7 +73,7 @@ public:
 
 private:
 
-    boost::scoped_ptr<Impl> _impl;
+    std::unique_ptr<Impl> _impl;
 };
 
 

--- a/include/lsst/shapelet/GaussHermiteConvolution.h
+++ b/include/lsst/shapelet/GaussHermiteConvolution.h
@@ -28,7 +28,7 @@
 #include "lsst/afw/geom/ellipses.h"
 #include "lsst/shapelet/HermiteTransformMatrix.h"
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 namespace lsst { namespace shapelet {
 

--- a/include/lsst/shapelet/MultiShapeletFunction.h
+++ b/include/lsst/shapelet/MultiShapeletFunction.h
@@ -38,8 +38,8 @@ class MultiShapeletFunctionEvaluator;
 class MultiShapeletFunction {
 public:
 
-    typedef boost::shared_ptr<MultiShapeletFunction> Ptr;
-    typedef boost::shared_ptr<MultiShapeletFunction const> ConstPtr;
+    typedef std::shared_ptr<MultiShapeletFunction> Ptr;
+    typedef std::shared_ptr<MultiShapeletFunction const> ConstPtr;
 
     typedef MultiShapeletFunctionEvaluator Evaluator;
 
@@ -91,8 +91,8 @@ private:
 class MultiShapeletFunctionEvaluator {
 public:
 
-    typedef boost::shared_ptr<MultiShapeletFunctionEvaluator> Ptr;
-    typedef boost::shared_ptr<MultiShapeletFunctionEvaluator const> ConstPtr;
+    typedef std::shared_ptr<MultiShapeletFunctionEvaluator> Ptr;
+    typedef std::shared_ptr<MultiShapeletFunctionEvaluator const> ConstPtr;
 
     /// @brief Evaluate at the given point.
     double operator()(double x, double y) const {

--- a/include/lsst/shapelet/ShapeletFunction.h
+++ b/include/lsst/shapelet/ShapeletFunction.h
@@ -65,8 +65,8 @@ class ShapeletFunctionEvaluator;
 class ShapeletFunction {
 public:
 
-    typedef boost::shared_ptr<ShapeletFunction> Ptr;
-    typedef boost::shared_ptr<ShapeletFunction const> ConstPtr;
+    typedef std::shared_ptr<ShapeletFunction> Ptr;
+    typedef std::shared_ptr<ShapeletFunction const> ConstPtr;
 
     typedef ShapeletFunctionEvaluator Evaluator;
 
@@ -177,8 +177,8 @@ private:
 class ShapeletFunctionEvaluator {
 public:
 
-    typedef boost::shared_ptr<ShapeletFunctionEvaluator> Ptr;
-    typedef boost::shared_ptr<ShapeletFunctionEvaluator const> ConstPtr;
+    typedef std::shared_ptr<ShapeletFunctionEvaluator> Ptr;
+    typedef std::shared_ptr<ShapeletFunctionEvaluator const> ConstPtr;
 
     /// @brief Evaluate at the given point.
     double operator()(double x, double y) const {

--- a/src/FunctorKeys.cc
+++ b/src/FunctorKeys.cc
@@ -81,7 +81,7 @@ MultiShapeletFunctionKey MultiShapeletFunctionKey::addFields(
     result._components.reserve(orders.size());
     for (std::size_t i = 0; i < orders.size(); ++i) {
         result._components.push_back(
-            boost::make_shared<ShapeletFunctionKey>(
+            std::make_shared<ShapeletFunctionKey>(
                 ShapeletFunctionKey::addFields(
                     schema,
                     schema[name][boost::lexical_cast<std::string>(i)].getPrefix(),
@@ -104,7 +104,7 @@ MultiShapeletFunctionKey::MultiShapeletFunctionKey(
     std::size_t i = 0;
     while (true) {
         try {
-            PTR(ShapeletFunctionKey) component = boost::make_shared<ShapeletFunctionKey>(
+            PTR(ShapeletFunctionKey) component = std::make_shared<ShapeletFunctionKey>(
                 s[boost::lexical_cast<std::string>(i)],
                 basisType
             );

--- a/src/MatrixBuilder.cc
+++ b/src/MatrixBuilder.cc
@@ -22,7 +22,7 @@
  */
 
 #include <cmath>
-#include "boost/make_shared.hpp"
+#include <memory>
 #include "ndarray/eigen.h"
 
 #include "lsst/shapelet/MatrixBuilder.h"

--- a/src/MatrixBuilder.cc
+++ b/src/MatrixBuilder.cc
@@ -218,7 +218,7 @@ public:
         int getLhsOrder() const { return _lhsOrder; }
 
         virtual PTR(typename MatrixBuilder<T>::Impl) makeBuilderImpl(Workspace & workspace) const {
-            return boost::make_shared<ShapeletImpl>(*this, &workspace);
+            return std::make_shared<ShapeletImpl>(*this, &workspace);
         }
 
     private:
@@ -354,7 +354,7 @@ public:
         ShapeletFunction const & getPsf() const { return _psf; }
 
         virtual PTR(typename MatrixBuilder<T>::Impl) makeBuilderImpl(Workspace & workspace) const {
-            return boost::make_shared<ConvolvedShapeletImpl>(*this, &workspace);
+            return std::make_shared<ConvolvedShapeletImpl>(*this, &workspace);
         }
 
     protected:
@@ -450,7 +450,7 @@ public:
         ndarray::Array<double const,2,2> getRemapMatrix() const { return _remapMatrix; }
 
         virtual PTR(typename MatrixBuilder<T>::Impl) makeBuilderImpl(Workspace & workspace) const {
-            return boost::make_shared<RemappedShapeletImpl>(*this, &workspace);
+            return std::make_shared<RemappedShapeletImpl>(*this, &workspace);
         }
 
     protected:
@@ -548,7 +548,7 @@ public:
         ndarray::Array<double const,2,2> getRemapMatrix() const { return _remapMatrix; }
 
         virtual PTR(typename MatrixBuilder<T>::Impl) makeBuilderImpl(Workspace & workspace) const {
-            return boost::make_shared<RemappedConvolvedShapeletImpl>(*this, &workspace);
+            return std::make_shared<RemappedConvolvedShapeletImpl>(*this, &workspace);
         }
 
     protected:
@@ -633,7 +633,7 @@ public:
             _components.reserve(basis.getComponentCount());
             for (MultiShapeletBasis::Iterator i = basis.begin(); i != basis.end(); ++i) {
                 _components.push_back(
-                    boost::make_shared< typename RemappedShapeletImpl<T>::Factory >(
+                    std::make_shared< typename RemappedShapeletImpl<T>::Factory >(
                         x, y, i->getOrder(), i->getRadius(), i->getMatrix()
                     )
                 );
@@ -654,7 +654,7 @@ public:
                     ++j
                 ) {
                     _components.push_back(
-                        boost::make_shared< typename RemappedConvolvedShapeletImpl<T>::Factory >(
+                        std::make_shared< typename RemappedConvolvedShapeletImpl<T>::Factory >(
                             x, y, i->getOrder(), i->getRadius(), i->getMatrix(), *j
                         )
                     );
@@ -688,7 +688,7 @@ public:
             // Now, at the end, we increment the workspace by the amount we claimed we needed, which was
             // the maximum needed by any individual components.
             workspace.increment(computeWorkspace());
-            return boost::make_shared<CompoundImpl>(builders);
+            return std::make_shared<CompoundImpl>(builders);
         }
 
     private:
@@ -842,7 +842,7 @@ MatrixBuilderFactory<T>::MatrixBuilderFactory(
     ndarray::Array<T const,1,1> const & x,
     ndarray::Array<T const,1,1> const & y,
     int order
-) : _impl(boost::make_shared< typename ShapeletImpl<T>::Factory >(x, y, order))
+) : _impl(std::make_shared< typename ShapeletImpl<T>::Factory >(x, y, order))
 {}
 
 template <typename T>
@@ -851,7 +851,7 @@ MatrixBuilderFactory<T>::MatrixBuilderFactory(
     ndarray::Array<T const,1,1> const & y,
     int order,
     ShapeletFunction const & psf
-) : _impl(boost::make_shared< typename ConvolvedShapeletImpl<T>::Factory >(x, y, order, psf))
+) : _impl(std::make_shared< typename ConvolvedShapeletImpl<T>::Factory >(x, y, order, psf))
 {}
 
 namespace {
@@ -879,14 +879,14 @@ MatrixBuilderFactory<T>::MatrixBuilderFactory(
     if (basis.getComponentCount() == 1) {
         MultiShapeletBasisComponent const & component = *basis.begin();
         if (isSimple(component)) {
-            _impl = boost::make_shared< typename ShapeletImpl<T>::Factory >(x, y, component.getOrder());
+            _impl = std::make_shared< typename ShapeletImpl<T>::Factory >(x, y, component.getOrder());
         } else {
-            _impl = boost::make_shared< typename RemappedShapeletImpl<T>::Factory >(
+            _impl = std::make_shared< typename RemappedShapeletImpl<T>::Factory >(
                 x, y, component.getOrder(), component.getRadius(), component.getMatrix()
             );
         }
     } else {
-        _impl = boost::make_shared< typename CompoundImpl<T>::Factory >(x, y, basis);
+        _impl = std::make_shared< typename CompoundImpl<T>::Factory >(x, y, basis);
     }
 }
 
@@ -901,16 +901,16 @@ MatrixBuilderFactory<T>::MatrixBuilderFactory(
         ShapeletFunction const & psfComponent = psf.getComponents().front();
         MultiShapeletBasisComponent const & component = *basis.begin();
         if (isSimple(component)) {
-            _impl = boost::make_shared< typename ConvolvedShapeletImpl<T>::Factory >(
+            _impl = std::make_shared< typename ConvolvedShapeletImpl<T>::Factory >(
                 x, y, component.getOrder(), psfComponent
             );
         } else {
-            _impl = boost::make_shared< typename RemappedConvolvedShapeletImpl<T>::Factory >(
+            _impl = std::make_shared< typename RemappedConvolvedShapeletImpl<T>::Factory >(
                 x, y, component.getOrder(), component.getRadius(), component.getMatrix(), psfComponent
             );
         }
     } else {
-        _impl = boost::make_shared< typename CompoundImpl<T>::Factory >(x, y, basis, psf);
+        _impl = std::make_shared< typename CompoundImpl<T>::Factory >(x, y, basis, psf);
     }
 }
 

--- a/src/RadialProfile.cc
+++ b/src/RadialProfile.cc
@@ -21,7 +21,7 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 
-#include "boost/make_shared.hpp"
+#include <memory>
 #include "boost/math/special_functions/gamma.hpp"
 
 #include "lsst/shapelet/RadialProfile.h"

--- a/src/RadialProfile.cc
+++ b/src/RadialProfile.cc
@@ -68,7 +68,7 @@ public:
     explicit GaussianRadialProfile() :
         SersicRadialProfile("gaussian", 0.5, 0)
     {
-        PTR(MultiShapeletBasis) basis = boost::make_shared<MultiShapeletBasis>(1);
+        PTR(MultiShapeletBasis) basis = std::make_shared<MultiShapeletBasis>(1);
         ndarray::Array<double,2,2> matrix = ndarray::allocate(1,1);
         matrix.deep() = 0.5 / std::sqrt(afw::geom::PI);
         basis->addComponent(_momentsRadiusFactor, 0, matrix);
@@ -172,7 +172,7 @@ PTR(MultiShapeletBasis) RadialProfile::getBasis(int nComponents, int maxRadius) 
     }
     // Ideally, we'd return a const ptr instead of copying, but because Swig casts away the
     // constness, that's not sufficiently safe.
-    return boost::make_shared<MultiShapeletBasis>(*i->second);
+    return std::make_shared<MultiShapeletBasis>(*i->second);
 }
 
 void RadialProfile::registerBasis(PTR(MultiShapeletBasis) basis, int nComponents, int maxRadius) {


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
