### PR TITLE
DM-14740: Stop using ndarray::EigenView indirectly in C++ code

### DIFF
--- a/examples/timeModels.cc
+++ b/examples/timeModels.cc
@@ -52,9 +52,9 @@ double buildModelsImpl(
     ndarray::Array<T,2,-2> matrix = matrixT.transpose();
     double result = 0.0;
     for (ndarray::Array<double const,2>::Iterator i = parameters.begin(); i != parameters.end(); ++i) {
-        ellipse.setParameterVector(i->asEigen());
+        ellipse.setParameterVector(ndarray::asEigenMatrix(*i));
         builder(matrix, ellipse);
-        result += matrix.asEigen().norm();
+        result += ndarray::asEigenMatrix(matrix).norm();
     }
     return result;
 }

--- a/src/ConversionMatrix.cc
+++ b/src/ConversionMatrix.cc
@@ -190,7 +190,7 @@ void ConversionMatrix::multiplyOnLeft(
     } else {
         i = ConversionSingleton::get().getL2H().begin();
     }
-    auto vector = array.asEigen();
+    auto vector = ndarray::asEigenMatrix(array);
     for (int offset = 0; offset < vector.size(); ++i) {
         vector.segment(offset, i->rows()).transpose() *= i->transpose();
         offset += i->rows();
@@ -214,7 +214,7 @@ void ConversionMatrix::multiplyOnRight(
     } else {
         i = ConversionSingleton::get().getL2H().begin();
     }
-    auto vector = array.asEigen();
+    auto vector = ndarray::asEigenMatrix(array);
     for (int offset = 0; offset < vector.size(); ++i) {
         vector.segment(offset, i->rows()).transpose() *= (*i);
         offset += i->rows();

--- a/src/GaussHermiteConvolution.cc
+++ b/src/GaussHermiteConvolution.cc
@@ -237,8 +237,8 @@ ImplN::ImplN(
 ndarray::Array<double const,2,2> ImplN::evaluate(
     afw::geom::ellipses::Ellipse & ellipse
 ) const {
-    auto result = _result.asEigen();
-    auto psf_coeff = _psf.getCoefficients().asEigen();
+    auto result = ndarray::asEigenMatrix(_result);
+    auto psf_coeff = ndarray::asEigenMatrix(_psf.getCoefficients());
 
     Eigen::Matrix2d psfT = _psf.getEllipse().getCore().getGridTransform().invert().getMatrix();
     Eigen::Matrix2d modelT = ellipse.getCore().getGridTransform().invert().getMatrix();

--- a/src/MultiShapeletBasis.cc
+++ b/src/MultiShapeletBasis.cc
@@ -70,7 +70,7 @@ void MultiShapeletBasis::normalize() {
     for (ComponentVector::iterator i = _components.begin(); i != _components.end(); ++i) {
         ndarray::Array<double,2,2> newMatrix = ndarray::copy(i->getMatrix());
         for (int n = 0; n < _size; ++n) {
-            newMatrix.asEigen().col(n) /= totals[n];
+            ndarray::asEigenMatrix(newMatrix).col(n) /= totals[n];
         }
         i->_matrix = newMatrix;
     }
@@ -109,8 +109,8 @@ MultiShapeletFunction MultiShapeletBasis::makeFunction(
     for (Iterator i = begin(); i != end(); ++i) {
         result.getComponents().push_back(ShapeletFunction(i->getOrder(), HERMITE, ellipse));
         result.getComponents().back().getEllipse().getCore().scale(i->getRadius());
-        result.getComponents().back().getCoefficients().asEigen()
-            = i->getMatrix().asEigen() * coefficients.asEigen();
+        ndarray::asEigenMatrix(result.getComponents().back().getCoefficients())
+            = ndarray::asEigenMatrix(i->getMatrix()) * ndarray::asEigenMatrix(coefficients);
     }
     return result;
 }

--- a/src/ShapeletFunction.cc
+++ b/src/ShapeletFunction.cc
@@ -169,13 +169,14 @@ ShapeletFunctionEvaluator::ShapeletFunctionEvaluator(
 ShapeletFunction ShapeletFunction::convolve(ShapeletFunction const & other) const {
     GaussHermiteConvolution convolution(getOrder(), other);
     afw::geom::ellipses::Ellipse newEllipse(_ellipse);
-    auto matrix = convolution.evaluate(newEllipse).asEigen();
+    auto matrixNdArray = convolution.evaluate(newEllipse);
     if (_basisType == LAGUERRE) {
         ConversionMatrix::convertCoefficientVector(_coefficients, LAGUERRE, HERMITE, getOrder());
     }
     ShapeletFunction result(convolution.getRowOrder(), HERMITE);
     result.setEllipse(newEllipse);
-    result.getCoefficients().asEigen() = matrix * _coefficients.asEigen();
+    ndarray::asEigenMatrix(result.getCoefficients()) =
+            ndarray::asEigenMatrix(matrixNdArray) * ndarray::asEigenMatrix(_coefficients);
     if (_basisType == LAGUERRE) {
         ConversionMatrix::convertCoefficientVector(_coefficients, HERMITE, LAGUERRE, getOrder());
         result.changeBasisType(LAGUERRE);


### PR DESCRIPTION
Replace ndarray::Array::asEigen, which returns an ndarray::EigenView,
with ndarray::asEigen, which  returns an Eigen::Map