### PR TITLE
DM-36718: Sort components by sum of values

### DIFF
--- a/python/lsst/shapelet/tests.py
+++ b/python/lsst/shapelet/tests.py
@@ -96,7 +96,7 @@ class ShapeletTestCase(lsst.utils.tests.TestCase):
                 params = tuple(s.getEllipse().getParameterVector()) + tuple(s.getCoefficients())
                 keep.append((params, s))
         msf = lsst.shapelet.MultiShapeletFunction()
-        keep.sort(key=lambda t: t[0])
+        keep.sort(key=lambda t: numpy.sum(t[0]))
         for params, s in keep:
             msf.addComponent(s)
         return msf


### PR DESCRIPTION
Sorting by array values critically depends on the precision of the values being compared and on some platforms this can lead to inconsistent sort order. Sorting by the sum of the values is more robust.